### PR TITLE
fixed addDealer-form

### DIFF
--- a/server/models/Dealer.js
+++ b/server/models/Dealer.js
@@ -2,10 +2,6 @@ const { Schema, model } = require('mongoose');
 const dateFormat = require('../utils/dateFormat');
 
 const DealerSchema = new Schema ({
-    id: {
-      type: Number,
-      required: true,
-    },
     firstName: {
       type: String,
       required: true,

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -15,7 +15,8 @@
         "express": "^4.17.2",
         "graphql": "^16.6.0",
         "jsonwebtoken": "^8.5.1",
-        "mongoose": "^7.0.2"
+        "mongoose": "^7.6.8",
+        "uuid": "^9.0.1"
       },
       "devDependencies": {
         "nodemon": "^2.0.3"

--- a/server/package.json
+++ b/server/package.json
@@ -18,8 +18,8 @@
     "express": "^4.17.2",
     "graphql": "^16.6.0",
     "jsonwebtoken": "^8.5.1",
-    "mongoose": "^7.0.2"
-  },
+    "mongoose": "^7.6.8"
+    },
   "devDependencies": {
     "nodemon": "^2.0.3"
   }

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -66,6 +66,7 @@ const resolvers = {
           lastName,
           email,
         });
+        console.log(newDealer);
         return newDealer;
       } catch (error) {
         console.error('Error adding dealer:', error);

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -12,9 +12,11 @@ user: User
 }
 
 type Dealer {
+_id: ID
 firstName: String
 lastName: String
 email: String
+createdAt: String
 reports: [Report]
 }
 


### PR DESCRIPTION
I deleted the ID input filed from the Dealer schema model to fix the 400 error code when adding a new dealer to the database. When we create a new object, MongoDB assigns one by default, which means no need to specify one in the model; the reason I came to this conclusion is that I managed to add a new dealer by importing a new library that will add an ID to the created object, and as a result, in the terminal, the dealer had two id fields:


id: "whatever1234"
 _id: new ObjectId("whatever6784361"




